### PR TITLE
Add log level controls and instrumentation

### DIFF
--- a/ast-component-renderer/src/logger.ts
+++ b/ast-component-renderer/src/logger.ts
@@ -1,0 +1,76 @@
+export type LogLevel = "debug" | "info" | "warn" | "error" | "off";
+
+export const LOG_LEVELS: readonly LogLevel[] = ["debug", "info", "warn", "error", "off"] as const;
+export const DEFAULT_LOG_LEVEL: LogLevel = "info";
+
+export const LOG_LEVEL_LABELS: Record<LogLevel, string> = {
+  debug: "Debug (very verbose)",
+  info: "Info (recommended)",
+  warn: "Warn (warnings & errors)",
+  error: "Error only",
+  off: "Off",
+};
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  off: 50,
+};
+
+type LevelGetter = () => LogLevel | undefined;
+
+let globalLevelGetter: LevelGetter = () => DEFAULT_LOG_LEVEL;
+
+export function normalizeLogLevel(value: unknown, fallback: LogLevel = DEFAULT_LOG_LEVEL): LogLevel {
+  if (typeof value === "string") {
+    const normalized = value.toLowerCase() as LogLevel;
+    if ((LOG_LEVELS as readonly string[]).includes(normalized)) return normalized;
+  }
+  return fallback;
+}
+
+export class ScopedLogger {
+  constructor(private readonly scope: string, private readonly levelGetter: LevelGetter) {}
+
+  private shouldLog(level: LogLevel): boolean {
+    const current = normalizeLogLevel(this.levelGetter?.(), DEFAULT_LOG_LEVEL);
+    return LEVEL_RANK[level] >= LEVEL_RANK[current];
+  }
+
+  private withScope(args: any[]): any[] {
+    return [`[${this.scope}]`, ...args];
+  }
+
+  debug(...args: any[]): void {
+    if (this.shouldLog("debug")) console.debug(...this.withScope(args));
+  }
+
+  info(...args: any[]): void {
+    if (this.shouldLog("info")) console.info(...this.withScope(args));
+  }
+
+  warn(...args: any[]): void {
+    if (this.shouldLog("warn")) console.warn(...this.withScope(args));
+  }
+
+  error(...args: any[]): void {
+    if (this.shouldLog("error")) console.error(...this.withScope(args));
+  }
+}
+
+export function setLoggerLevelGetter(getter: LevelGetter | undefined): void {
+  if (typeof getter === "function") {
+    globalLevelGetter = () => normalizeLogLevel(getter(), DEFAULT_LOG_LEVEL);
+  } else {
+    globalLevelGetter = () => DEFAULT_LOG_LEVEL;
+  }
+}
+
+export function createLogger(scope: string, getter?: LevelGetter): ScopedLogger {
+  const levelGetter = getter
+    ? () => normalizeLogLevel(getter(), DEFAULT_LOG_LEVEL)
+    : () => globalLevelGetter();
+  return new ScopedLogger(scope, levelGetter);
+}

--- a/ast-component-renderer/src/mount.ts
+++ b/ast-component-renderer/src/mount.ts
@@ -1,9 +1,8 @@
 import type { MarkdownPostProcessorContext } from "obsidian";
 import type { MdNode, MountPolicy } from "./types.js";
+import { createLogger } from "./logger.js";
 
-const VERBOSE = true;
-const tag = (m: string) => `[ACR:mount] ${m}`;
-const dbg = (...a: any[]) => VERBOSE && console.debug(...a);
+const log = createLogger("ACR:mount");
 
 export function pickAnchorByLinesInScope(
   scopeEl: HTMLElement,
@@ -12,7 +11,7 @@ export function pickAnchorByLinesInScope(
 ): HTMLElement | null {
   const sLine = (node?.position?.start?.line ?? 1) - 1;
   const eLine = (node?.position?.end?.line ?? sLine + 1) - 1;
-  dbg(tag(`pickAnchor scope=${scopeEl.tagName}.${scopeEl.className} node=${sLine}-${eLine}`));
+  log.debug("pickAnchor", { scope: `${scopeEl.tagName}.${scopeEl.className}`, range: `${sLine}-${eLine}` });
 
   const candidates: HTMLElement[] = [scopeEl];
   const selector = [
@@ -32,12 +31,17 @@ export function pickAnchorByLinesInScope(
     considered++;
     const inside = !(sLine < sec.lineStart || eLine > sec.lineEnd);
     const span = sec.lineEnd - sec.lineStart;
-    dbg(tag(`cand ${el.tagName}.${el.className} sec=L${sec.lineStart}–L${sec.lineEnd} inside=${inside} span=${span}`));
+    log.debug("anchor candidate", {
+      element: `${el.tagName}.${el.className}`,
+      section: `L${sec.lineStart}–L${sec.lineEnd}`,
+      inside,
+      span,
+    });
     if (!inside) continue;
     if (!best || span < best.span) best = { el, span };
   }
 
-  dbg(tag(`candidates considered=${considered} chosen=${best?.el?.tagName || "none"}`), best?.el || null);
+  log.debug("anchor selection result", { considered, chosen: best?.el?.tagName ?? "none" });
   return best?.el ?? null;
 }
 

--- a/ast-component-renderer/src/settings.ts
+++ b/ast-component-renderer/src/settings.ts
@@ -1,0 +1,38 @@
+import { App, PluginSettingTab, Setting } from "obsidian";
+import type ASTComponentRenderer from "./main";
+import { LOG_LEVEL_LABELS, LOG_LEVELS, type LogLevel } from "./logger";
+
+export interface RendererSettings {
+  logLevel: LogLevel;
+}
+
+export const DEFAULT_SETTINGS: RendererSettings = {
+  logLevel: "info",
+};
+
+export class RendererSettingsTab extends PluginSettingTab {
+  constructor(app: App, private readonly plugin: ASTComponentRenderer) {
+    super(app, plugin);
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+    containerEl.createEl("h2", { text: "AST Component Renderer – Settings" });
+
+    new Setting(containerEl)
+      .setName("Log level")
+      .setDesc("Controls how much logging is emitted to the developer console.")
+      .addDropdown(drop => {
+        for (const level of LOG_LEVELS) {
+          drop.addOption(level, LOG_LEVEL_LABELS[level]);
+        }
+        drop
+          .setValue(this.plugin.settings.logLevel)
+          .onChange(async value => {
+            this.plugin.settings.logLevel = value as LogLevel;
+            await this.plugin.saveSettings();
+          });
+      });
+  }
+}

--- a/obsidian-ast/src/logger.ts
+++ b/obsidian-ast/src/logger.ts
@@ -1,0 +1,76 @@
+export type LogLevel = "debug" | "info" | "warn" | "error" | "off";
+
+export const LOG_LEVELS: readonly LogLevel[] = ["debug", "info", "warn", "error", "off"] as const;
+export const DEFAULT_LOG_LEVEL: LogLevel = "info";
+
+export const LOG_LEVEL_LABELS: Record<LogLevel, string> = {
+  debug: "Debug (very verbose)",
+  info: "Info (recommended)",
+  warn: "Warn (warnings & errors)",
+  error: "Error only",
+  off: "Off",
+};
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  off: 50,
+};
+
+type LevelGetter = () => LogLevel | undefined;
+
+let globalLevelGetter: LevelGetter = () => DEFAULT_LOG_LEVEL;
+
+export function normalizeLogLevel(value: unknown, fallback: LogLevel = DEFAULT_LOG_LEVEL): LogLevel {
+  if (typeof value === "string") {
+    const normalized = value.toLowerCase() as LogLevel;
+    if ((LOG_LEVELS as readonly string[]).includes(normalized)) return normalized;
+  }
+  return fallback;
+}
+
+export class ScopedLogger {
+  constructor(private readonly scope: string, private readonly levelGetter: LevelGetter) {}
+
+  private shouldLog(level: LogLevel): boolean {
+    const current = normalizeLogLevel(this.levelGetter?.(), DEFAULT_LOG_LEVEL);
+    return LEVEL_RANK[level] >= LEVEL_RANK[current];
+  }
+
+  private withScope(args: any[]): any[] {
+    return [`[${this.scope}]`, ...args];
+  }
+
+  debug(...args: any[]): void {
+    if (this.shouldLog("debug")) console.debug(...this.withScope(args));
+  }
+
+  info(...args: any[]): void {
+    if (this.shouldLog("info")) console.info(...this.withScope(args));
+  }
+
+  warn(...args: any[]): void {
+    if (this.shouldLog("warn")) console.warn(...this.withScope(args));
+  }
+
+  error(...args: any[]): void {
+    if (this.shouldLog("error")) console.error(...this.withScope(args));
+  }
+}
+
+export function setLoggerLevelGetter(getter: LevelGetter | undefined): void {
+  if (typeof getter === "function") {
+    globalLevelGetter = () => normalizeLogLevel(getter(), DEFAULT_LOG_LEVEL);
+  } else {
+    globalLevelGetter = () => DEFAULT_LOG_LEVEL;
+  }
+}
+
+export function createLogger(scope: string, getter?: LevelGetter): ScopedLogger {
+  const levelGetter = getter
+    ? () => normalizeLogLevel(getter(), DEFAULT_LOG_LEVEL)
+    : () => globalLevelGetter();
+  return new ScopedLogger(scope, levelGetter);
+}

--- a/obsidian-ast/src/main.ts
+++ b/obsidian-ast/src/main.ts
@@ -21,6 +21,7 @@ import { remarkDirectivesExtension } from "./mdast-extensions/remark-directive-e
 
 import { AstSettings, DEFAULT_SETTINGS, AstSettingsTab } from "./settings";
 import { selectExtended, enrichFieldsAndTags, makeChain, AstChai } from "./unit-select-extention";
+import { createLogger, normalizeLogLevel, setLoggerLevelGetter } from "./logger";
 
 import { remarkDirectiveAdapter } from "./mdast-extensions/remark-directive-extension/from-directive";
 
@@ -43,6 +44,7 @@ export default class AstPlugin extends Plugin {
   private cache = new Map<string, AstEntry>();
   private processor!: Processor;
   public settings: AstSettings = { ...DEFAULT_SETTINGS };
+  private log = createLogger("obsidian-ast", () => this.settings.logLevel);
 
   /** Public API for DataviewJS etc. */
   public api!: AstApi;
@@ -52,43 +54,70 @@ export default class AstPlugin extends Plugin {
   }
 
   async onload() {
+    this.log.info("onload start");
     await this.loadSettings();
+    this.log.debug("settings loaded", { settings: this.settings });
+
     this.rebuildProcessor();
 
     // Expose chain API (for DataviewJS)
     this.api = {
       ast: (path: string) => {
+        this.log.debug("api.ast invoked", { path });
         const astPromise = this.ensureParsedByPath(path);
         const nodesPromise = astPromise.then(ast => (ast ? [ast as unknown as MdastNode] : []));
         return makeChain(astPromise, nodesPromise);
       }
     };
-    this.register(() => ((this as any).api = undefined));
+    this.register(() => {
+      this.log.debug("api disposed");
+      (this as any).api = undefined;
+    });
 
     // Vault events to keep cache fresh
     this.registerEvent(this.app.vault.on("modify", async (f) => {
-      if (f instanceof TFile && f.extension === "md") await this.ensureParsed(f);
+      if (f instanceof TFile && f.extension === "md") {
+        this.log.debug("vault modify event", { path: f.path });
+        await this.ensureParsed(f);
+      }
     }));
     this.registerEvent(this.app.vault.on("rename", (f, oldPath) => {
       if (f instanceof TFile && f.extension === "md") {
+        this.log.debug("vault rename event", { from: oldPath, to: f.path });
         const e = this.cache.get(oldPath);
-        if (e) { this.cache.delete(oldPath); this.cache.set(f.path, e); }
+        if (e) {
+          this.cache.delete(oldPath);
+          this.cache.set(f.path, e);
+          this.log.debug("cache entry moved", { from: oldPath, to: f.path });
+        }
       }
     }));
     this.registerEvent(this.app.vault.on("delete", (f) => {
-      if (f instanceof TFile && f.extension === "md") this.cache.delete(f.path);
+      if (f instanceof TFile && f.extension === "md") {
+        this.log.debug("vault delete event", { path: f.path });
+        this.cache.delete(f.path);
+      }
     }));
 
     // ```ast code blocks
     this.registerMarkdownCodeBlockProcessor("ast", async (src, el, ctx) => {
+      const selector = src.trim();
+      this.log.debug("code block processor invoked", { selector, sourcePath: ctx.sourcePath });
       try {
-        const selector = src.trim();
         if (!selector) throw new Error("selector missing");
         const ast = await this.ensureParsedByPath(ctx.sourcePath);
-        if (!ast) { el.setText("(no AST)"); return; }
+        if (!ast) {
+          this.log.warn("code block aborted: no AST available", { sourcePath: ctx.sourcePath });
+          el.setText("(no AST)");
+          return;
+        }
 
         const nodes = selectExtended(ast as any, selector, [ast as any]);
-        if (!nodes.length) { el.setText("(no matches)"); return; }
+        this.log.debug("code block selector result", { selector, count: nodes.length });
+        if (!nodes.length) {
+          el.setText("(no matches)");
+          return;
+        }
 
         for (const n of nodes) {
           const block = el.createDiv({ cls: "ast-match" });
@@ -96,6 +125,7 @@ export default class AstPlugin extends Plugin {
           block.createEl("hr");
         }
       } catch (e) {
+        this.log.error("code block render failed", e);
         el.setText(`ast error: ${(e as Error).message}`);
       }
     });
@@ -105,11 +135,21 @@ export default class AstPlugin extends Plugin {
       id: "show-current-file-ast-counts",
       name: "Show AST summary for current file",
       callback: async () => {
+        this.log.debug("command invoked: show-current-file-ast-counts");
         const file = this.getActiveFile();
-        if (!file) { new Notice("No active file."); return; }
+        if (!file) {
+          this.log.warn("command aborted: no active file");
+          new Notice("No active file.");
+          return;
+        }
         const ast = await this.ensureParsed(file);
-        if (!ast) { new Notice("Could not parse current file."); return; }
+        if (!ast) {
+          this.log.warn("command aborted: AST unavailable", { path: file.path });
+          new Notice("Could not parse current file.");
+          return;
+        }
         const c = countByType(ast);
+        this.log.info("command result", { path: file.path, counts: c });
         new Notice(
           `Types: ${Object.keys(c).length}. ` +
           `H:${c["heading"] ?? 0} P:${c["paragraph"] ?? 0} ` +
@@ -120,40 +160,66 @@ export default class AstPlugin extends Plugin {
 
     // Settings tab
     this.addSettingTab(new AstSettingsTab(this.app, this));
+    this.log.info("onload complete");
   }
 
   onunload() {
+    this.log.info("onunload");
     this.cache.clear();
+    setLoggerLevelGetter(undefined);
   }
 
   /* ---------- settings ---------- */
   async loadSettings() {
     const data = await this.loadData();
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, data || {});
+    const merged = Object.assign({}, DEFAULT_SETTINGS, data || {});
+    merged.logLevel = normalizeLogLevel(merged.logLevel, DEFAULT_SETTINGS.logLevel);
+    this.settings = merged;
+    setLoggerLevelGetter(() => this.settings.logLevel);
+    this.log.debug("loadSettings complete", { settings: this.settings });
   }
 
   async saveSettings() {
+    this.settings.logLevel = normalizeLogLevel(this.settings.logLevel, DEFAULT_SETTINGS.logLevel);
+    setLoggerLevelGetter(() => this.settings.logLevel);
+    this.log.info("saveSettings", { settings: this.settings });
     await this.saveData(this.settings);
     await this.rebuildProcessor();
     this.cache.clear(); // force reparse so toggles take effect
+    this.log.debug("cache cleared after save");
   }
 
   /* ---------- processor ---------- */
   private rebuildProcessor = () => {
-    console.info("[obsidian-ast] rebuildProcessor start");
+    this.log.info("rebuildProcessor start");
     try {
       let p = unified().use(remarkParse).use(remarkGfm);
 
-      if (this.settings.enableMdTag) p = p.use(remarkMdTag);
-      if (this.settings.enableInlineField) p = p.use(remarkInlineField);
-      if (this.settings.enableDirectives) p = p.use(remarkDirectivesExtension);
-      if (this.settings.enableCallout) p = p.use(remarkCallout);
-      if (this.settings.enableNestedHeadings) p = p.use(remarkNestedHeading);
+      if (this.settings.enableMdTag) {
+        this.log.debug("enabling mdTag extension");
+        p = p.use(remarkMdTag);
+      }
+      if (this.settings.enableInlineField) {
+        this.log.debug("enabling inline field extension");
+        p = p.use(remarkInlineField);
+      }
+      if (this.settings.enableDirectives) {
+        this.log.debug("enabling directives extension");
+        p = p.use(remarkDirectivesExtension);
+      }
+      if (this.settings.enableCallout) {
+        this.log.debug("enabling callout extension");
+        p = p.use(remarkCallout);
+      }
+      if (this.settings.enableNestedHeadings) {
+        this.log.debug("enabling nested headings extension");
+        p = p.use(remarkNestedHeading);
+      }
 
       this.processor = p;
-      console.info("[obsidian-ast] rebuildProcessor ok");
+      this.log.info("rebuildProcessor ok");
     } catch (e) {
-      console.error("[obsidian-ast] processor build failed; falling back:", e);
+      this.log.error("processor build failed; falling back", e);
       new Notice("obsidian-ast: fell back to basic parser (see console)", 5000);
       this.processor = unified().use(remarkParse).use(remarkGfm);
     }
@@ -169,25 +235,46 @@ export default class AstPlugin extends Plugin {
 
   private async ensureParsedByPath(path: string): Promise<MdastRoot | undefined> {
     const f = this.app.vault.getAbstractFileByPath(path);
-    if (!(f instanceof TFile) || f.extension !== "md") return;
+    if (!(f instanceof TFile) || f.extension !== "md") {
+      this.log.debug("ensureParsedByPath skip: not a markdown file", { path });
+      return;
+    }
+    this.log.debug("ensureParsedByPath resolved file", { path: f.path });
     return this.ensureParsed(f);
   }
 
   private async ensureParsed(f: TFile): Promise<MdastRoot | undefined> {
-    if (f.extension !== "md") return;
+    if (f.extension !== "md") {
+      this.log.debug("ensureParsed skip: not markdown", { path: f.path, extension: f.extension });
+      return;
+    }
     const stat = await this.app.vault.adapter.stat(f.path);
     const size = stat?.size ?? 0, mtime = stat?.mtime ?? 0;
     const prev = this.cache.get(f.path);
-    if (prev && prev.mtime === mtime && prev.size === size) return prev.ast;
+    if (prev && prev.mtime === mtime && prev.size === size) {
+      this.log.debug("cache hit", { path: f.path, mtime, size });
+      return prev.ast;
+    }
 
-    const raw = await this.app.vault.read(f);
-    const ast = await this.processor.run(this.processor.parse(raw)) as MdastRoot;
+    this.log.debug("cache miss", { path: f.path, mtime, size, hadPrevious: !!prev });
 
-    // Enrich: collect fields/tags from inline nodes, callouts, and titles
-    enrichFieldsAndTags(ast);
+    try {
+      const raw = await this.app.vault.read(f);
+      this.log.debug("file read", { path: f.path, length: raw.length });
+      const ast = await this.processor.run(this.processor.parse(raw)) as MdastRoot;
+      this.log.debug("ast parsed", { path: f.path });
 
-    this.cache.set(f.path, { ast, mtime, size, raw });
-    return ast;
+      // Enrich: collect fields/tags from inline nodes, callouts, and titles
+      enrichFieldsAndTags(ast);
+      this.log.debug("ast enriched", { path: f.path });
+
+      this.cache.set(f.path, { ast, mtime, size, raw });
+      this.log.debug("cache updated", { path: f.path, mtime, size });
+      return ast;
+    } catch (error) {
+      this.log.error("failed to parse file", { path: f.path }, error);
+      throw error;
+    }
   }
 }
 

--- a/obsidian-ast/src/mdast-extensions/remark-directive-extension/bundle.ts
+++ b/obsidian-ast/src/mdast-extensions/remark-directive-extension/bundle.ts
@@ -2,22 +2,26 @@
 import type { Plugin, Processor } from "unified";
 import remarkDirectiveDefault from "remark-directive";
 import { remarkDirectiveAdapter } from "./from-directive";
+import { createLogger } from "../../logger";
 
 // Normalize ESM/CJS export just in case
 const remarkDirective: any =
   (remarkDirectiveDefault as any)?.default ?? remarkDirectiveDefault;
 
+const log = createLogger("obsidian-ast:remark-directives");
+
 /** Unified plugin that installs remark-directive + our adapter */
 export const remarkDirectivesExtension: Plugin<[]> = function (this: Processor) {
   try {
     if (typeof remarkDirective !== "function") {
+      log.warn("remark-directive export is not callable", { type: typeof remarkDirective });
       throw new Error("remark-directive is not a function");
     }
     this.use(remarkDirective);
     this.use(remarkDirectiveAdapter);
-    // console.info("[obsidian-ast] remarkDirectivesExtension loaded");
+    log.debug("remarkDirectivesExtension loaded");
   } catch (e) {
     // Never rethrow — keep the rest of the pipeline alive
-    console.error("[obsidian-ast] remarkDirectivesExtension failed:", e);
+    log.error("remarkDirectivesExtension failed", e);
   }
 };

--- a/obsidian-ast/src/settings.ts
+++ b/obsidian-ast/src/settings.ts
@@ -1,5 +1,6 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import type AstPlugin from "./main";
+import { LOG_LEVEL_LABELS, LOG_LEVELS, type LogLevel } from "./logger";
 
 export interface AstSettings {
   enableMdTag: boolean;
@@ -7,6 +8,7 @@ export interface AstSettings {
   enableCallout: boolean;
   enableNestedHeadings: boolean;
   enableDirectives: boolean;
+  logLevel: LogLevel;
 }
 
 export const DEFAULT_SETTINGS: AstSettings = {
@@ -15,6 +17,7 @@ export const DEFAULT_SETTINGS: AstSettings = {
   enableCallout: true,
   enableNestedHeadings: true,
   enableDirectives: true,
+  logLevel: "info",
 };
 
 export class AstSettingsTab extends PluginSettingTab {
@@ -29,6 +32,21 @@ export class AstSettingsTab extends PluginSettingTab {
     const { containerEl } = this;
     containerEl.empty();
     containerEl.createEl("h2", { text: "AST Tools – Settings" });
+
+    new Setting(containerEl)
+      .setName("Log level")
+      .setDesc("Controls how much information is printed to the developer console.")
+      .addDropdown(drop => {
+        for (const level of LOG_LEVELS) {
+          drop.addOption(level, LOG_LEVEL_LABELS[level]);
+        }
+        drop
+          .setValue(this.plugin.settings.logLevel)
+          .onChange(async value => {
+            this.plugin.settings.logLevel = value as LogLevel;
+            await this.plugin.saveSettings();
+          });
+      });
 
     new Setting(containerEl)
       .setName("MdTag (#tag)")


### PR DESCRIPTION
## Summary
- add logger utilities and log-level settings for the obsidian-ast plugin
- route parser, cache, and directive extension logging through the configurable logger
- add logging controls and instrumentation for the ast-component-renderer plugin and its mounting helpers

## Testing
- npm test (obsidian-ast)
- npm test (ast-component-renderer)

------
https://chatgpt.com/codex/tasks/task_e_68c9991666708324bd57031ffbeba3ae