### PR TITLE
Refine AST transforms and renderer policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Working Change Log
+
+## Planned Work
+- [x] Align callout transform structure with documented node shape (Paragraph title, unioned positions) and add coverage.
+- [x] Restructure nested heading transform to emit Paragraph titles, preserve positions, and test union behaviour.
+- [x] Extend selector traversal/parent mapping to include special node-list fields (e.g., `title`) and cover direct/recursive operators.
+- [x] Strengthen position fidelity tests for slices/unions across callouts and headings.
+- [x] Update renderer mount policies and placement helpers to match documented options and add targeted tests.
+- [x] Improve anchor selection heuristics for headings, list items, callout title/body, with JSDOM coverage.
+- [x] Add renderer lifecycle handling (Svelte cleanup) and ensure dedupe/cleanup behaviour in tests.

--- a/ast-component-renderer/src/__tests__/registry.test.ts
+++ b/ast-component-renderer/src/__tests__/registry.test.ts
@@ -10,7 +10,9 @@ describe("InMemoryRegistry", () => {
   const createRenderer = (): ComponentRenderer => ({
     render: (node: MdNode, target: HTMLElement) => {
       target.dataset.rendered = node.type;
-      return target;
+    },
+    cleanup: (target: HTMLElement) => {
+      delete target.dataset.rendered;
     }
   });
 

--- a/ast-component-renderer/src/__tests__/svelteRenderer.test.ts
+++ b/ast-component-renderer/src/__tests__/svelteRenderer.test.ts
@@ -9,16 +9,21 @@ setupDom();
 class FakeComponent {
   static lastInstance: FakeComponent | null = null;
   public options: { target: HTMLElement; props: Record<string, unknown> };
+  public destroyed = false;
 
   constructor(options: { target: HTMLElement; props: Record<string, unknown> }) {
     this.options = options;
     FakeComponent.lastInstance = this;
   }
+
+  $destroy() {
+    this.destroyed = true;
+  }
 }
 
 describe("SvelteRenderer", () => {
   it("instantiates the Svelte component with merged props", () => {
-    const renderer = new SvelteRenderer(FakeComponent as any, { extra: true }, "after-anchor");
+    const renderer = new SvelteRenderer(FakeComponent as any, { extra: true }, "after-heading");
     const mountTarget = document.createElement("div");
     const node: MdNode = { type: "comment" };
 
@@ -29,9 +34,7 @@ describe("SvelteRenderer", () => {
       ctx: {} as any
     };
 
-    const returned = renderer.render(node, mountTarget, rc);
-
-    assert.equal(returned, mountTarget);
+    renderer.render(node, mountTarget, rc);
     assert.equal(FakeComponent.lastInstance?.options.target, mountTarget);
     assert.deepEqual(FakeComponent.lastInstance?.options.props, {
       node,
@@ -45,5 +48,19 @@ describe("SvelteRenderer", () => {
   it("exposes the mount policy passed to the constructor", () => {
     const renderer = new SvelteRenderer(FakeComponent as any, {}, "append-inside-li");
     assert.equal(renderer.mountPolicy, "append-inside-li");
+  });
+
+  it("destroys mounted components during cleanup", () => {
+    const renderer = new SvelteRenderer(FakeComponent as any, {});
+    const mountTarget = document.createElement("div");
+    const node: MdNode = { type: "comment" };
+    const rc: RenderContext = { app: {} as any, plugin: {} as any, filePath: "demo.md", ctx: {} as any };
+
+    renderer.render(node, mountTarget, rc);
+    const instance = FakeComponent.lastInstance;
+    assert.ok(instance && !instance.destroyed);
+
+    renderer.cleanup(mountTarget);
+    assert.equal(instance?.destroyed, true);
   });
 });

--- a/ast-component-renderer/src/mount.ts
+++ b/ast-component-renderer/src/mount.ts
@@ -4,6 +4,20 @@ import { createLogger } from "./logger.js";
 
 const log = createLogger("ACR:mount");
 
+type Candidate = { el: HTMLElement; priority: number };
+
+function addSelectors(scope: HTMLElement, selectors: string[], priority: number, into: Candidate[], seen: Set<HTMLElement>) {
+  for (const selector of selectors) {
+    if (!selector) continue;
+    const matches = scope.querySelectorAll<HTMLElement>(selector);
+    for (const el of Array.from(matches)) {
+      if (seen.has(el)) continue;
+      seen.add(el);
+      into.push({ el, priority });
+    }
+  }
+}
+
 export function pickAnchorByLinesInScope(
   scopeEl: HTMLElement,
   ctx: MarkdownPostProcessorContext,
@@ -13,44 +27,104 @@ export function pickAnchorByLinesInScope(
   const eLine = (node?.position?.end?.line ?? sLine + 1) - 1;
   log.debug("pickAnchor", { scope: `${scopeEl.tagName}.${scopeEl.className}`, range: `${sLine}-${eLine}` });
 
-  const candidates: HTMLElement[] = [scopeEl];
-  const selector = [
-    "li.task-list-item","li","p","blockquote",
-    "h1,h2,h3,h4,h5,h6","table","thead","tbody","tr","td","th",
-    "pre","code","div"
-  ].join(",");
-  const matches = scopeEl.querySelectorAll<HTMLElement>(selector);
-  for (const el of Array.from(matches)) candidates.push(el);
+  const candidates: Candidate[] = [];
+  const seen = new Set<HTMLElement>();
+  const push = (el: HTMLElement | null, priority: number) => {
+    if (!el || seen.has(el)) return;
+    seen.add(el);
+    candidates.push({ el, priority });
+  };
 
-  let best: { el: HTMLElement; span: number } | null = null;
+  push(scopeEl, 3);
+
+  const type = node?.type ?? "";
+  if (type === "heading") addSelectors(scopeEl, ["h1", "h2", "h3", "h4", "h5", "h6"], 0, candidates, seen);
+  if (type === "listItem") addSelectors(scopeEl, ["li.task-list-item", "li"], 0, candidates, seen);
+  if (type === "callout") addSelectors(scopeEl, [".callout-title", ".callout-content", ".callout"], 0, candidates, seen);
+  if (type === "paragraph") addSelectors(scopeEl, ["p"], 0, candidates, seen);
+
+  addSelectors(scopeEl, [
+    ".callout-title",
+    ".callout-content",
+    ".callout",
+    "li.task-list-item",
+    "li",
+    "p",
+    "blockquote",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "td",
+    "th",
+    "pre",
+    "code",
+    "div"
+  ], 1, candidates, seen);
+
+  let best: (Candidate & {
+    covers: boolean;
+    exact: boolean;
+    span: number;
+    gap: number;
+    overlap: number;
+  }) | null = null;
   let considered = 0;
 
-  for (const el of candidates) {
-    const sec = ctx.getSectionInfo(el);
+  for (const cand of candidates) {
+    const sec = ctx.getSectionInfo(cand.el);
     if (!sec) continue;
     considered++;
-    const inside = !(sLine < sec.lineStart || eLine > sec.lineEnd);
-    const span = sec.lineEnd - sec.lineStart;
+    const start = sec.lineStart;
+    const end = sec.lineEnd;
+    const covers = sLine >= start && eLine <= end;
+    const overlapRaw = Math.min(eLine, end) - Math.max(sLine, start);
+    const overlap = overlapRaw >= 0 ? overlapRaw : -1;
+    if (overlap < 0 && !covers) continue;
+    const exact = covers && start === sLine && end === eLine;
+    const span = Math.max(0, end - start);
+    const gap = Math.abs(start - sLine) + Math.abs(end - eLine);
     log.debug("anchor candidate", {
-      element: `${el.tagName}.${el.className}`,
+      element: `${cand.el.tagName}.${cand.el.className}`,
       section: `L${sec.lineStart}–L${sec.lineEnd}`,
-      inside,
+      covers,
       span,
+      priority: cand.priority
     });
-    if (!inside) continue;
-    if (!best || span < best.span) best = { el, span };
+    const score = { ...cand, covers, exact, span, gap, overlap };
+    if (!best || compareCandidates(score, best) < 0) best = score;
   }
 
   log.debug("anchor selection result", { considered, chosen: best?.el?.tagName ?? "none" });
   return best?.el ?? null;
 }
 
+function compareCandidates(a: { covers: boolean; exact: boolean; span: number; gap: number; overlap: number; priority: number }, b: { covers: boolean; exact: boolean; span: number; gap: number; overlap: number; priority: number }): number {
+  if (a.covers !== b.covers) return a.covers ? -1 : 1;
+  if (a.priority !== b.priority) return a.priority - b.priority;
+  if (a.exact !== b.exact) return a.exact ? -1 : 1;
+  if (a.span !== b.span) return a.span - b.span;
+  if (a.gap !== b.gap) return a.gap - b.gap;
+  if (a.overlap !== b.overlap) return b.overlap - a.overlap;
+  return 0;
+}
+
 export function placeMount(policy: MountPolicy, anchor: HTMLElement): HTMLElement {
   const host = document.createElement("div");
-  if (policy === "before-anchor") anchor.parentElement?.insertBefore(host, anchor);
-  else if (policy === "after-anchor") anchor.parentElement?.insertBefore(host, anchor.nextSibling);
-  else if (policy === "append-inside-li") (anchor.closest("li") ?? anchor).appendChild(host);
-  else anchor.appendChild(host);
+  if (policy === "append-inside-li") {
+    (anchor.closest("li") ?? anchor).appendChild(host);
+  } else if (policy === "after-heading") {
+    if (anchor.parentElement) anchor.parentElement.insertBefore(host, anchor.nextSibling);
+    else anchor.appendChild(host);
+  } else {
+    anchor.appendChild(host);
+  }
   return host;
 }
 

--- a/ast-component-renderer/src/renderers/svelte.ts
+++ b/ast-component-renderer/src/renderers/svelte.ts
@@ -1,18 +1,28 @@
 import type { ComponentRenderer, RenderContext, MdNode, MountPolicy } from "../types.js";
 
 export class SvelteRenderer implements ComponentRenderer {
+  private instances = new WeakMap<HTMLElement, any>();
   constructor(
     private SvelteComponent: any,
     private defaultProps: Record<string, any> = {},
     public mountPolicy: MountPolicy = "append-inside-block"
   ) {}
-  render(node: MdNode, mountTarget: HTMLElement, rc: RenderContext): HTMLElement {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const app = new this.SvelteComponent({
+  render(node: MdNode, mountTarget: HTMLElement, rc: RenderContext): void {
+    const prev = this.instances.get(mountTarget);
+    if (prev && typeof prev.$destroy === "function") prev.$destroy();
+    const instance = new this.SvelteComponent({
       target: mountTarget,
       props: { node, filePath: rc.filePath, app: rc.app, plugin: rc.plugin, ...this.defaultProps }
     });
-    return mountTarget;
+    this.instances.set(mountTarget, instance);
+  }
+
+  cleanup(mountTarget: HTMLElement): void {
+    const instance = this.instances.get(mountTarget);
+    if (instance && typeof instance.$destroy === "function") {
+      instance.$destroy();
+    }
+    this.instances.delete(mountTarget);
   }
 }
 

--- a/ast-component-renderer/src/types.ts
+++ b/ast-component-renderer/src/types.ts
@@ -4,7 +4,7 @@ export type MdPoint = { line?: number; column?: number; offset?: number };
 export type MdPosition = { start?: MdPoint; end?: MdPoint };
 export interface MdNode { type: string; position?: MdPosition; [k: string]: any; }
 
-export type MountPolicy = "append-inside-block" | "append-inside-li" | "before-anchor" | "after-anchor";
+export type MountPolicy = "append-inside-block" | "append-inside-li" | "after-heading";
 
 export interface RenderContext {
   app: App;
@@ -14,9 +14,10 @@ export interface RenderContext {
 }
 
 export interface ComponentRenderer {
-  render(node: MdNode, mountTarget: HTMLElement, rc: RenderContext): Promise<HTMLElement> | HTMLElement;
+  render(node: MdNode, mountTarget: HTMLElement, rc: RenderContext): Promise<void> | void;
   mountPolicy?: MountPolicy;
   pickAnchor?(node: MdNode, root: HTMLElement, rc: RenderContext): HTMLElement | null;
+  cleanup?(mountTarget: HTMLElement): void;
 }
 
 export interface RegistryEntry { type: string; renderer: ComponentRenderer; }

--- a/obsidian-ast/package.json
+++ b/obsidian-ast/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf dist main.js obsidian-ast.zip .test-build",
     "test": "npm run test:run",
     "test:build": "node -e \"process.exit(0)\"",
-    "test:run": "node --test --loader ./scripts/ts-loader.mjs src/unit-select-extention/__tests__/enrich.test.ts src/unit-select-extention/__tests__/expand.test.ts src/unit-select-extention/__tests__/selector-chain.test.ts"
+    "test:run": "node --test --loader ./scripts/ts-loader.mjs src/unit-select-extention/__tests__/enrich.test.ts src/unit-select-extention/__tests__/expand.test.ts src/unit-select-extention/__tests__/selector-chain.test.ts src/mdast-extensions/__tests__/transforms.test.ts"
   },
   "devDependencies": {
     "@types/node": "^22.18.1",

--- a/obsidian-ast/scripts/stubs/unist-util-visit.ts
+++ b/obsidian-ast/scripts/stubs/unist-util-visit.ts
@@ -1,7 +1,35 @@
-export function visit(tree: any, visitor: (node: any, index: number | null, parent: any | null) => void): void {
+type Visitor = (node: any, index: number | null, parent: any | null) => void;
+
+export function visit(tree: any, testOrVisitor: any, maybeVisitor?: Visitor): void {
+  const collectChildren = (node: any): any[] => {
+    const out: any[] = [];
+    if (Array.isArray(node?.children)) out.push(...node.children);
+    const title = node?.title;
+    if (Array.isArray(title)) out.push(...title);
+    else if (title) out.push(title);
+    return out;
+  };
+
+  let test: ((node: any) => boolean) | null = null;
+  let visitor: Visitor;
+
+  if (typeof testOrVisitor === "function" && !maybeVisitor) {
+    visitor = testOrVisitor as Visitor;
+  } else {
+    visitor = (maybeVisitor ?? (() => {})) as Visitor;
+    const testVal = testOrVisitor;
+    if (typeof testVal === "string") {
+      test = (node: any) => node?.type === testVal;
+    } else if (Array.isArray(testVal)) {
+      test = (node: any) => testVal.includes(node?.type);
+    } else if (typeof testVal === "function") {
+      test = testVal;
+    }
+  }
+
   function walk(node: any, index: number | null, parent: any | null) {
-    visitor(node, index, parent);
-    const children = Array.isArray(node?.children) ? node.children : [];
+    if (!test || test(node)) visitor(node, index, parent);
+    const children = collectChildren(node);
     for (let i = 0; i < children.length; i++) {
       walk(children[i], i, node);
     }

--- a/obsidian-ast/src/mdast-extensions/__tests__/transforms.test.ts
+++ b/obsidian-ast/src/mdast-extensions/__tests__/transforms.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Root } from "mdast";
+import { transformCallouts } from "../remark-callout/transform";
+import { transformNestedHeadings } from "../remark-nested-heading/transform";
+
+const pos = (start: number, end: number, line = 1) => ({
+  position: {
+    start: { offset: start, line, column: start + 1 },
+    end: { offset: end, line, column: end + 1 }
+  }
+});
+
+describe("remark callout transform", () => {
+  it("wraps the callout title in a paragraph and unions positions", () => {
+    const blockquote: any = {
+      type: "blockquote",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            { type: "text", value: "[!note]+ Title", ...pos(0, 14) }
+          ],
+          ...pos(0, 14)
+        },
+        {
+          type: "paragraph",
+          children: [{ type: "text", value: "Body", ...pos(15, 19) }],
+          ...pos(15, 19)
+        }
+      ],
+      ...pos(0, 19)
+    };
+
+    const root: Root = { type: "root", children: [blockquote], ...pos(0, 19) } as any;
+
+    transformCallouts()(root);
+
+    const callout = root.children[0] as any;
+    assert.equal(callout.type, "callout");
+    assert.equal(callout.calloutType, "note");
+    assert.equal(callout.expanded, "open");
+    assert.equal(callout.title.type, "paragraph");
+    assert.equal(callout.title.children[0].value, "Title");
+    assert.equal(callout.children.length, 1);
+    assert.equal(callout.children[0].children[0].value, "Body");
+    assert.equal(callout.position.start.offset, 0);
+    assert.equal(callout.position.end.offset, 19);
+    assert.equal(callout.title.position.start.offset, 0);
+    assert.equal(callout.title.position.end.offset, 14);
+  });
+});
+
+describe("remark nested heading transform", () => {
+  it("promotes inline children to a title paragraph and unions section range", () => {
+    const heading: any = {
+      type: "heading",
+      depth: 2,
+      children: [{ type: "text", value: "Section", ...pos(0, 7) }],
+      ...pos(0, 7)
+    };
+    const paragraph: any = {
+      type: "paragraph",
+      children: [{ type: "text", value: "Content", ...pos(8, 15) }],
+      ...pos(8, 15)
+    };
+    const root: Root = { type: "root", children: [heading, paragraph], ...pos(0, 15) } as any;
+
+    transformNestedHeadings()(root);
+
+    assert.equal(root.children.length, 1);
+    const section = root.children[0] as any;
+    assert.equal(section.type, "heading");
+    assert.equal(section.title.type, "paragraph");
+    assert.equal(section.title.children[0].value, "Section");
+    assert.equal(section.children.length, 1);
+    assert.equal(section.children[0], paragraph);
+    assert.equal(section.position.start.offset, 0);
+    assert.equal(section.position.end.offset, 15);
+    assert.equal(section.title.position.start.offset, 0);
+    assert.equal(section.title.position.end.offset, 7);
+  });
+});

--- a/obsidian-ast/src/mdast-extensions/remark-callout/to-markdown.ts
+++ b/obsidian-ast/src/mdast-extensions/remark-callout/to-markdown.ts
@@ -18,12 +18,12 @@ function prefixBlockquote(value: string): string {
 
 const handleCallout: Handle = (node, _parent, context) => {
   const n = node as unknown as Callout
-  const marker = `[!${n.calloutType}]${n.expanded ?? ''}`
+  const suffix = n.expanded === 'open' ? '+' : n.expanded === 'closed' ? '-' : ''
+  const marker = `[!${n.calloutType}]${suffix}`
 
   let titleInline = ''
-  if (n.title?.length) {
-    // Wrap phrasing in a synthetic paragraph so containerPhrasing can serialize.
-    titleInline = context.containerPhrasing({type: 'paragraph', children: n.title}, {before: '', after: ''}).trim()
+  if (n.title?.children?.length) {
+    titleInline = context.containerPhrasing(n.title as any, {before: '', after: ''}).trim()
   }
 
   const firstLine = '> ' + marker + (titleInline ? ' ' + titleInline : '') + '\n'

--- a/obsidian-ast/src/mdast-extensions/remark-callout/types.ts
+++ b/obsidian-ast/src/mdast-extensions/remark-callout/types.ts
@@ -1,19 +1,19 @@
 /**
  * Callout node:
  * - calloutType: normalized lower-case type (e.g., "tip", "warning")
- * - expanded: '+' | '-' | undefined  (undefined if unknown/not present)
- * - title: usually a Paragraph node (optional; absent if none)
+ * - expanded: 'open' | 'closed' | undefined (undefined if unknown/not present)
+ * - title: Paragraph node (always present, may be empty)
  * - children: the callout's content blocks
  */
 import type {Parent} from 'unist'
-import type {PhrasingContent, BlockContent} from 'mdast'
+import type {BlockContent, Paragraph} from 'mdast'
 
 export interface Callout extends Parent {
   type: 'callout'
   calloutType: string
-  expanded?: '+' | '-'
-  /** Title phrasing on the first line (no paragraph wrapper) */
-  title?: PhrasingContent[]
+  expanded?: 'open' | 'closed'
+  /** Title paragraph extracted from the first line */
+  title: Paragraph
   children: BlockContent[]
 }
 

--- a/obsidian-ast/src/mdast-extensions/remark-nested-heading/types.ts
+++ b/obsidian-ast/src/mdast-extensions/remark-nested-heading/types.ts
@@ -8,11 +8,11 @@
  * section-aware code.
  */
 
-import type {Heading, BlockContent, PhrasingContent} from "mdast"
+import type {Heading, BlockContent, Paragraph} from "mdast"
 
 export interface HeadingSection extends Heading {
-  /** Phrasing children copied from the original heading line */
-  title?: PhrasingContent[]
+  /** Paragraph copied from the original heading line */
+  title: Paragraph
   /** Section body blocks (including nested HeadingSection) */
   children: Array<BlockContent | HeadingSection>
   /** Internal marker to avoid re-sectionizing */
@@ -22,8 +22,8 @@ export interface HeadingSection extends Heading {
 // Optional augmentation: expose `title` on mdast Heading for TS convenience.
 declare module "mdast" {
   interface Heading {
-    /** Phrasing from the heading line, if sectionized by this plugin */
-    title?: PhrasingContent[]
+    /** Paragraph from the heading line, if sectionized by this plugin */
+    title: Paragraph
     /** (At runtime after sectionizing) children are section body blocks */
     // Note: we don't alter the declared type of children here.
   }

--- a/obsidian-ast/src/unit-select-extention/__tests__/enrich.test.ts
+++ b/obsidian-ast/src/unit-select-extention/__tests__/enrich.test.ts
@@ -15,8 +15,12 @@ describe("enrichFieldsAndTags", () => {
     const heading = {
       type: "heading",
       depth: 1,
-      children: [{ type: "text", value: "Heading", ...pos(0) }],
-      title: [{ type: "inlineField", key: "owner", value: "Ada", ...pos(10) }],
+      title: {
+        type: "paragraph",
+        children: [{ type: "inlineField", key: "owner", value: "Ada", ...pos(10) }],
+        ...pos(0, 5)
+      },
+      children: [],
       ...pos(0, 5)
     } as any;
 

--- a/obsidian-ast/src/unit-select-extention/enrich.ts
+++ b/obsidian-ast/src/unit-select-extention/enrich.ts
@@ -29,7 +29,7 @@ export function enrichFieldsAndTags(ast: MdastRoot) {
     if (n?.type === "paragraph" || n?.type === "heading" || n?.type === "tableCell") harvestInline(n, n);
 
     // If you sectionized headings, also index title phrasing
-    if (n?.type === "heading" && n.title) harvestInline({ type: "paragraph", children: n.title }, n);
+    if (n?.type === "heading" && n.title) harvestInline(n.title, n);
 
     // List item: read first paragraph
     if (n?.type === "listItem" && Array.isArray(n.children)) {
@@ -39,7 +39,7 @@ export function enrichFieldsAndTags(ast: MdastRoot) {
 
     // Callouts: title + body
     if (n?.type === "callout") {
-      if (n.title) harvestInline(n.title, n);
+      harvestInline(n.title, n);
       for (const c of (n.children || [])) harvestInline(c, n);
     }
   });


### PR DESCRIPTION
## Summary
- restructure callout handling to emit paragraph titles with open/closed state, adjust serialization, and add focused unit tests
- sectionize headings with paragraph nodes while updating selector traversal and comparison logic to cover special fields
- align component renderer mount policies, anchor heuristics, and Svelte cleanup with refreshed test coverage

## Testing
- npm test (obsidian-ast)
- npm test (ast-component-renderer)

------
https://chatgpt.com/codex/tasks/task_e_68c9a11fac0c8324885e9ecc74f1d279