### PR TITLE
Align AST transforms and traversal with title participation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+## Work in Progress
+
+- [x] Align callout transformation with the documented node shape (paragraph title, position union).
+- [x] Restructure nested heading titles into paragraph nodes and verify section positioning.
+- [x] Extend selector traversal/parent maps to include structural fields like `title`.
+- [x] Update enrichment and selector tests to cover the new shapes and traversal paths.

--- a/obsidian-ast/package-lock.json
+++ b/obsidian-ast/package-lock.json
@@ -22,6 +22,7 @@
         "cpx": "^1.5.0",
         "esbuild": "^0.23.1",
         "obsidian": "^1.8.7",
+        "rimraf": "^6.0.1",
         "typescript": "^5.9.2"
       }
     },
@@ -456,6 +457,101 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/@marijn/find-cluster-break": {
@@ -1024,6 +1120,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -1137,6 +1253,21 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/css-selector-parser": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.1.3.tgz",
@@ -1244,6 +1375,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/elegant-spinner": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -1252,6 +1390,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.23.1",
@@ -1441,6 +1586,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fragment-cache": {
@@ -1966,6 +2128,13 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
@@ -1976,6 +2145,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/kind-of": {
@@ -2020,6 +2205,16 @@
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
       "integrity": "sha512-84jGpz/1j02Xm/L4y4uEXGxFFPHFabKjMHQ+rEPi0gPQbD5p0J3aZomvk0ZpUPpTtcVqhtSEq+4WNQbJjWiZ1Q==",
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/map-cache": {
       "version": "0.2.2",
@@ -3031,6 +3226,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -3330,6 +3535,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -3394,12 +3606,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/pify": {
       "version": "2.3.0",
@@ -3956,6 +4195,66 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -3998,6 +4297,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shell-quote": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
@@ -4016,6 +4338,19 @@
       "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz",
       "integrity": "sha512-CI1ViFC5a3ub86aaBmBVQ7kqg8eFypZLgBh+Bmq+ehHy9g7vu9kqCj5hS82cPzLwfdJRgiPB2hNHnd6oetiakQ==",
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
@@ -4223,6 +4558,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -4247,6 +4631,30 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4729,6 +5137,190 @@
       "license": "MIT",
       "dependencies": {
         "wrap-fn": "^0.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrap-fn": {

--- a/obsidian-ast/package.json
+++ b/obsidian-ast/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf dist main.js obsidian-ast.zip .test-build",
     "test": "npm run test:run",
     "test:build": "node -e \"process.exit(0)\"",
-    "test:run": "node --test --loader ./scripts/ts-loader.mjs src/unit-select-extention/__tests__/enrich.test.ts src/unit-select-extention/__tests__/expand.test.ts src/unit-select-extention/__tests__/selector-chain.test.ts"
+    "test:run": "node --test --loader ./scripts/ts-loader.mjs src/unit-select-extention/__tests__/enrich.test.ts src/unit-select-extention/__tests__/expand.test.ts src/unit-select-extention/__tests__/selector-chain.test.ts src/mdast-extensions/__tests__/transforms.test.ts"
   },
   "devDependencies": {
     "@types/node": "^22.18.1",

--- a/obsidian-ast/scripts/stubs/unist-util-visit.ts
+++ b/obsidian-ast/scripts/stubs/unist-util-visit.ts
@@ -1,10 +1,49 @@
-export function visit(tree: any, visitor: (node: any, index: number | null, parent: any | null) => void): void {
+type Visitor = (node: any, index: number | null, parent: any | null) => any;
+
+const SKIP = Symbol("skip");
+
+export function visit(tree: any, testOrVisitor: any, maybeVisitor?: Visitor): void {
+  let test: ((node: any) => boolean) | null = null;
+  let visitor: Visitor;
+
+  if (typeof testOrVisitor === "function" && !maybeVisitor) {
+    visitor = testOrVisitor as Visitor;
+  } else {
+    visitor = (maybeVisitor as Visitor) ?? (() => {});
+    if (typeof testOrVisitor === "string") {
+      test = (node: any) => node?.type === testOrVisitor;
+    } else if (Array.isArray(testOrVisitor)) {
+      const set = new Set(testOrVisitor);
+      test = (node: any) => set.has(node?.type);
+    } else if (typeof testOrVisitor === "function") {
+      test = testOrVisitor as (node: any) => boolean;
+    }
+  }
+
   function walk(node: any, index: number | null, parent: any | null) {
-    visitor(node, index, parent);
+    if (!test || test(node)) {
+      const result = visitor(node, index, parent);
+      if (result === SKIP || (Array.isArray(result) && result[0] === SKIP)) {
+        return;
+      }
+    }
+
     const children = Array.isArray(node?.children) ? node.children : [];
+    const title = node?.title;
+    const extra: any[] = [];
+    if (title) {
+      if (Array.isArray(title)) extra.push(...title);
+      else if (typeof title === "object") extra.push(title);
+    }
+    for (const child of extra) {
+      walk(child, null, node);
+    }
     for (let i = 0; i < children.length; i++) {
       walk(children[i], i, node);
     }
   }
+
   walk(tree, null, null);
 }
+
+visit.SKIP = SKIP;

--- a/obsidian-ast/src/mdast-extensions/__tests__/transforms.test.ts
+++ b/obsidian-ast/src/mdast-extensions/__tests__/transforms.test.ts
@@ -1,0 +1,105 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Root, Blockquote, Paragraph, Heading } from "mdast";
+import { transformCallouts } from "../remark-callout/transform";
+import { transformNestedHeadings } from "../remark-nested-heading/transform";
+
+const pos = (start: number, end: number = start + 1) => ({
+  start: { offset: start, line: 1, column: start + 1 },
+  end: { offset: end, line: 1, column: end + 1 }
+});
+
+describe("remark transforms", () => {
+  it("promotes blockquotes to callouts with paragraph titles", () => {
+    const titlePara: Paragraph = {
+      type: "paragraph",
+      children: [{ type: "text", value: "[!tip] Title", position: pos(5, 18) } as any],
+      position: pos(5, 18)
+    };
+    const bodyPara: Paragraph = {
+      type: "paragraph",
+      children: [{ type: "text", value: "Body", position: pos(18, 22) } as any],
+      position: pos(18, 22)
+    };
+    const blockquote: Blockquote = {
+      type: "blockquote",
+      children: [titlePara, bodyPara],
+      position: pos(0, 22)
+    } as any;
+    const root: Root = { type: "root", children: [blockquote], position: pos(0, 22) } as any;
+
+    transformCallouts()(root as any);
+
+    const callout = root.children[0] as any;
+    assert.equal(callout.type, "callout");
+    assert.equal(callout.calloutType, "tip");
+    assert.equal(callout.children.length, 1);
+    assert.strictEqual(callout.children[0], bodyPara);
+
+    const title = callout.title;
+    assert.equal(title?.type, "paragraph");
+    const text = title?.children?.[0] as any;
+    assert.equal(text.value, "Title");
+    assert.equal(title?.position?.start.offset, 5);
+    assert.equal(title?.position?.end.offset, 18);
+
+    assert.equal(callout.position?.start.offset, 0);
+    assert.equal(callout.position?.end.offset, 22);
+  });
+
+  it("wraps heading lines into paragraph titles and nests body", () => {
+    const heading: Heading = {
+      type: "heading",
+      depth: 1,
+      children: [{ type: "text", value: "Heading", position: pos(0, 7) } as any],
+      position: pos(0, 7)
+    } as any;
+
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      children: [{ type: "text", value: "Details", position: pos(8, 15) } as any],
+      position: pos(8, 15)
+    };
+
+    const subHeading: Heading = {
+      type: "heading",
+      depth: 2,
+      children: [{ type: "text", value: "Sub", position: pos(16, 20) } as any],
+      position: pos(16, 20)
+    } as any;
+
+    const subBody: Paragraph = {
+      type: "paragraph",
+      children: [{ type: "text", value: "Nested", position: pos(21, 28) } as any],
+      position: pos(21, 28)
+    };
+
+    const root: Root = {
+      type: "root",
+      children: [heading, paragraph, subHeading, subBody],
+      position: pos(0, 28)
+    } as any;
+
+    transformNestedHeadings()(root as any);
+
+    assert.equal(root.children.length, 1);
+    const section = root.children[0] as any;
+    assert.equal(section.type, "heading");
+    assert.equal(section.title?.type, "paragraph");
+    assert.equal(section.title?.children?.[0]?.value, "Heading");
+
+    assert.equal(section.children.length, 2);
+    assert.strictEqual(section.children[0], paragraph);
+
+    const nested = section.children[1] as any;
+    assert.equal(nested.type, "heading");
+    assert.equal(nested.title?.children?.[0]?.value, "Sub");
+    assert.equal(nested.children.length, 1);
+    assert.strictEqual(nested.children[0], subBody);
+
+    assert.equal(section.position?.start.offset, 0);
+    assert.equal(section.position?.end.offset, subBody.position?.end.offset);
+    assert.equal(nested.position?.start.offset, subHeading.position?.start.offset);
+    assert.equal(nested.position?.end.offset, subBody.position?.end.offset);
+  });
+});

--- a/obsidian-ast/src/mdast-extensions/helper.ts
+++ b/obsidian-ast/src/mdast-extensions/helper.ts
@@ -1,4 +1,4 @@
-import type { Position } from "unist";
+import type { Position, Point } from "unist";
 
 export function copyPos<T extends {position?: Position}>(dst: T, src?: {position?: Position}) {
   if (src?.position) dst.position = { 
@@ -8,11 +8,50 @@ export function copyPos<T extends {position?: Position}>(dst: T, src?: {position
   return dst;
 }
 
+function clonePoint(pt?: Point | null): Point | undefined {
+  if (!pt) return undefined;
+  return { ...pt } as Point;
+}
+
+function clonePosition(pos?: Position | null): Position | undefined {
+  if (!pos) return undefined;
+  return {
+    start: clonePoint(pos.start) ?? { offset: undefined, line: undefined, column: undefined },
+    end: clonePoint(pos.end) ?? { offset: undefined, line: undefined, column: undefined }
+  } as Position;
+}
+
+function comparePoints(a?: Point | null, b?: Point | null): number {
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  if (typeof a.offset === "number" && typeof b.offset === "number") return a.offset - b.offset;
+  if (typeof a.offset === "number") return -1;
+  if (typeof b.offset === "number") return 1;
+  if (typeof a.line === "number" && typeof b.line === "number") {
+    if (a.line !== b.line) return a.line - b.line;
+    const ac = typeof a.column === "number" ? a.column : 0;
+    const bc = typeof b.column === "number" ? b.column : 0;
+    return ac - bc;
+  }
+  if (typeof a.line === "number") return -1;
+  if (typeof b.line === "number") return 1;
+  return 0;
+}
+
 export function unionPos(a?: Position | null, b?: Position | null): Position | undefined {
   if (!a && !b) return undefined;
-  if (!a) return b as Position;
-  if (!b) return a as Position;
-  const start = (a.start.offset ?? 0) < (b.start.offset ?? Infinity) ? a.start : b.start;
-  const end   = (a.end.offset ?? 0)   > (b.end.offset ?? -Infinity)   ? a.end   : b.end;
+  if (!a) return clonePosition(b);
+  if (!b) return clonePosition(a);
+  const start = comparePoints(a.start, b.start) <= 0 ? clonePoint(a.start) : clonePoint(b.start);
+  const end = comparePoints(a.end, b.end) >= 0 ? clonePoint(a.end) : clonePoint(b.end);
   return { start, end } as Position;
+}
+
+export function unionAllPos(...positions: Array<Position | null | undefined>): Position | undefined {
+  let acc: Position | undefined;
+  for (const pos of positions) {
+    acc = unionPos(acc, pos);
+  }
+  return acc;
 }

--- a/obsidian-ast/src/mdast-extensions/remark-callout/to-markdown.ts
+++ b/obsidian-ast/src/mdast-extensions/remark-callout/to-markdown.ts
@@ -21,9 +21,8 @@ const handleCallout: Handle = (node, _parent, context) => {
   const marker = `[!${n.calloutType}]${n.expanded ?? ''}`
 
   let titleInline = ''
-  if (n.title?.length) {
-    // Wrap phrasing in a synthetic paragraph so containerPhrasing can serialize.
-    titleInline = context.containerPhrasing({type: 'paragraph', children: n.title}, {before: '', after: ''}).trim()
+  if (n.title) {
+    titleInline = context.containerPhrasing(n.title, {before: '', after: ''}).trim()
   }
 
   const firstLine = '> ' + marker + (titleInline ? ' ' + titleInline : '') + '\n'

--- a/obsidian-ast/src/mdast-extensions/remark-callout/types.ts
+++ b/obsidian-ast/src/mdast-extensions/remark-callout/types.ts
@@ -6,14 +6,14 @@
  * - children: the callout's content blocks
  */
 import type {Parent} from 'unist'
-import type {PhrasingContent, BlockContent} from 'mdast'
+import type {Paragraph, BlockContent} from 'mdast'
 
 export interface Callout extends Parent {
   type: 'callout'
   calloutType: string
   expanded?: '+' | '-'
-  /** Title phrasing on the first line (no paragraph wrapper) */
-  title?: PhrasingContent[]
+  /** Title paragraph extracted from the first line (optional) */
+  title?: Paragraph
   children: BlockContent[]
 }
 

--- a/obsidian-ast/src/mdast-extensions/remark-nested-heading/to-markdown.ts
+++ b/obsidian-ast/src/mdast-extensions/remark-nested-heading/to-markdown.ts
@@ -6,28 +6,21 @@
  */
 
 import type {ToMarkdownExtension, Handle} from "mdast-util-to-markdown"
-import type {Heading, PhrasingContent, Content} from "mdast"
+import type {Heading, Paragraph, Content, PhrasingContent} from "mdast"
 
 const handleHeading: Handle = (node, _parent, context) => {
-  const h = node as Heading & { title?: PhrasingContent[], children?: Content[] }
+  const h = node as Heading & { title?: Paragraph, children?: Content[] }
   const depth = h.depth ?? 1
   const marker = "#".repeat(Math.max(1, Math.min(6, depth)))
 
-  // Prefer our `title`; fallback to original phrasing if present
-  let phrasing: PhrasingContent[] | undefined = h.title
-  if (!phrasing || !phrasing.length) {
-    // If someone fed us a non-sectionized heading, fall back gracefully
-    if (Array.isArray(h.children) && h.children.length) {
-      // Only keep phrasing nodes from original children for the title
-      // (remark-parse ensures heading children are phrasing by default)
-      phrasing = h.children as any
-    } else {
-      phrasing = []
-    }
+  let titleParagraph: Paragraph | undefined = h.title
+  if (!titleParagraph) {
+    const fallbackChildren: PhrasingContent[] = Array.isArray(h.children) ? (h.children as any) : []
+    titleParagraph = { type: "paragraph", children: fallbackChildren }
   }
 
   const titleInline = context.containerPhrasing(
-    { type: "paragraph", children: phrasing },
+    titleParagraph,
     { before: "", after: "" }
   ).trim()
 

--- a/obsidian-ast/src/mdast-extensions/remark-nested-heading/types.ts
+++ b/obsidian-ast/src/mdast-extensions/remark-nested-heading/types.ts
@@ -8,11 +8,11 @@
  * section-aware code.
  */
 
-import type {Heading, BlockContent, PhrasingContent} from "mdast"
+import type {Heading, BlockContent, Paragraph, PhrasingContent} from "mdast"
 
 export interface HeadingSection extends Heading {
-  /** Phrasing children copied from the original heading line */
-  title?: PhrasingContent[]
+  /** Paragraph built from the original heading line */
+  title?: Paragraph
   /** Section body blocks (including nested HeadingSection) */
   children: Array<BlockContent | HeadingSection>
   /** Internal marker to avoid re-sectionizing */
@@ -22,8 +22,8 @@ export interface HeadingSection extends Heading {
 // Optional augmentation: expose `title` on mdast Heading for TS convenience.
 declare module "mdast" {
   interface Heading {
-    /** Phrasing from the heading line, if sectionized by this plugin */
-    title?: PhrasingContent[]
+    /** Paragraph from the heading line, if sectionized by this plugin */
+    title?: Paragraph
     /** (At runtime after sectionizing) children are section body blocks */
     // Note: we don't alter the declared type of children here.
   }

--- a/obsidian-ast/src/unit-select-extention/__tests__/enrich.test.ts
+++ b/obsidian-ast/src/unit-select-extention/__tests__/enrich.test.ts
@@ -12,11 +12,16 @@ const pos = (start: number, end: number = start + 1) => ({
 
 describe("enrichFieldsAndTags", () => {
   it("collects inline fields and tags across common containers", () => {
+    const headingTitle = {
+      type: "paragraph",
+      children: [{ type: "inlineField", key: "owner", value: "Ada", ...pos(10) }],
+      ...pos(9, 12)
+    } as any;
     const heading = {
       type: "heading",
       depth: 1,
       children: [{ type: "text", value: "Heading", ...pos(0) }],
-      title: [{ type: "inlineField", key: "owner", value: "Ada", ...pos(10) }],
+      title: headingTitle,
       ...pos(0, 5)
     } as any;
 

--- a/obsidian-ast/src/unit-select-extention/__tests__/expand.test.ts
+++ b/obsidian-ast/src/unit-select-extention/__tests__/expand.test.ts
@@ -10,11 +10,23 @@ const pos = (offset: number) => ({
 });
 
 describe("expandFieldChain", () => {
-  it("expands title arrays into paragraph nodes", () => {
+  it("returns paragraph titles directly", () => {
     const heading: any = {
       type: "heading",
-      title: [{ type: "text", value: "Hello", ...pos(0) }],
+      title: { type: "paragraph", children: [{ type: "text", value: "Hello", ...pos(0) }], ...pos(0) },
       ...pos(0)
+    };
+
+    const result = expandFieldChain([heading], ["title"]);
+    assert.equal(result.length, 1);
+    assert.strictEqual(result[0], heading.title);
+  });
+
+  it("wraps legacy title arrays into a paragraph", () => {
+    const heading: any = {
+      type: "heading",
+      title: [{ type: "text", value: "Legacy", ...pos(2) }],
+      ...pos(2)
     };
 
     const result = expandFieldChain([heading], ["title"]);

--- a/obsidian-ast/src/unit-select-extention/enrich.ts
+++ b/obsidian-ast/src/unit-select-extention/enrich.ts
@@ -29,7 +29,7 @@ export function enrichFieldsAndTags(ast: MdastRoot) {
     if (n?.type === "paragraph" || n?.type === "heading" || n?.type === "tableCell") harvestInline(n, n);
 
     // If you sectionized headings, also index title phrasing
-    if (n?.type === "heading" && n.title) harvestInline({ type: "paragraph", children: n.title }, n);
+    if (n?.type === "heading" && n.title) harvestInline(n.title, n);
 
     // List item: read first paragraph
     if (n?.type === "listItem" && Array.isArray(n.children)) {

--- a/obsidian-ast/src/unit-select-extention/traverse.ts
+++ b/obsidian-ast/src/unit-select-extention/traverse.ts
@@ -1,9 +1,44 @@
-import { visit } from "unist-util-visit";
+const isNode = (val: any): val is { type: string } => !!val && typeof val === "object" && typeof val.type === "string";
+const SKIP_KEYS = new Set(["parent", "position"]);
+
+function collectFromValue(value: any): any[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    if (!value.length) return [];
+    if (!value.every(isNode)) return [];
+    return value;
+  }
+  return isNode(value) ? [value] : [];
+}
+
+export function structuralChildren(node: any): any[] {
+  if (!node || typeof node !== "object") return [];
+  const out: any[] = [];
+  if (Array.isArray(node.children)) out.push(...node.children.filter(isNode));
+  else if (isNode(node.children)) out.push(node.children);
+
+  if (node.title) out.push(...collectFromValue(node.title));
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "children" || key === "title" || SKIP_KEYS.has(key)) continue;
+    out.push(...collectFromValue(value));
+  }
+  return out;
+}
 
 /** Collect every node inside scope (including scope) */
 export function runAllWithin(scope: any): any[] {
   const nodes: any[] = [];
-  visit(scope, (n: any) => { nodes.push(n); });
+  const stack: any[] = [scope];
+  const seen = new Set<any>();
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current || typeof current !== "object") continue;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    nodes.push(current);
+    for (const child of structuralChildren(current)) stack.push(child);
+  }
   return nodes;
 }
 
@@ -26,10 +61,19 @@ export function uniqueById(arr: any[]): any[] {
 
 /** Weak parent map (root → null, others → parent) */
 export function buildParentMap(root: any): WeakMap<any, any | null> {
-  const parents = new WeakMap<any, any | null>(); parents.set(root, null);
-  visit(root, (n: any, _i: number | null, p: any | null) => {
-    if (n && !parents.has(n)) parents.set(n, p ?? null);
-  });
+  const parents = new WeakMap<any, any | null>();
+  const stack: any[] = [root];
+  parents.set(root, null);
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current || typeof current !== "object") continue;
+    for (const child of structuralChildren(current)) {
+      if (!parents.has(child)) {
+        parents.set(child, current);
+        stack.push(child);
+      }
+    }
+  }
   return parents;
 }
 


### PR DESCRIPTION
## Summary
- normalize callout and nested-heading transforms to emit paragraph titles with accurate position unions
- extend selector traversal, parent mapping, and stubs so structural fields such as `title` participate in child/descendant queries
- refresh enrichment logic and add targeted unit coverage for transforms, selectors, and chain behaviours

## Testing
- npm test --workspace obsidian-ast
- npm test --workspace ast-component-renderer

------
https://chatgpt.com/codex/tasks/task_e_68c9a11fac0c8324885e9ecc74f1d279